### PR TITLE
change rules-id from int to string

### DIFF
--- a/leaguerule.go
+++ b/leaguerule.go
@@ -1,7 +1,7 @@
 package poego
 
 type Rules struct {
-	Id          int    `gorethink:"id" json:"id"`
+	Id          string    `gorethink:"id" json:"id"`
 	Name        string `gorethink:"name" json:"name"`
 	Description string `gorethink:"description" json:"description"`
 }


### PR DESCRIPTION
When calling `poego.GetLeagues(nil)` a json-marshalling error is returned. 
It seems the api has changed to make rules-id a string instead of int.

I know the repo is fairly old, and might contain other errors, but as of now this was the only thing I stumbled upon. 